### PR TITLE
Fix admin' substitute function

### DIFF
--- a/src/com/portfolio/data/provider/MysqlDataProvider.java
+++ b/src/com/portfolio/data/provider/MysqlDataProvider.java
@@ -295,6 +295,9 @@ public class MysqlDataProvider implements DataProvider {
 				return st.executeQuery();
 			}
 
+			if( credential.isAdmin(substid) )	// If root wants to debug user UI
+				substid = 0;
+
 			// On recupere d'abord les informations dans la table structures
 
 			/// XXX Dammit Oracle, why are you so useless?


### PR DESCRIPTION
In general use, a regular person can't see all the portfolios from the substitution, only the subset of what the replaced user and substitute can see.
Admins were following the same rule while they should be seeing all the replaced user's portfolios.