### PR TITLE
Performance fix

### DIFF
--- a/WebContent/version
+++ b/WebContent/version
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <versions>
 	<version id='backend'>
-		<number>1.1.0.2</number>
-		<date>2015-07-15</date>
+		<number>1.1.0.3</number>
+		<date>2015-07-16</date>
 	</version>
 	<version id='fileserver'>
 		<number>1.1.0.1</number>

--- a/sql/db_update_1.1.0.0_to_1.1.0.3.sql
+++ b/sql/db_update_1.1.0.0_to_1.1.0.3.sql
@@ -1,0 +1,11 @@
+-- Updating tables from Karuta 1.1.0.0 to Karuta 1.1.0.3
+
+USE `karuta-backend`;
+
+-- credential_group might have been used, better be safe and just alter it
+ALTER TABLE credential_group MODIFY COLUMN `cg` bigint NOT NULL AUTO_INCREMENT;
+ALTER TABLE credential_group ADD COLUMN `label` varchar(255) COLLATE utf8_unicode_ci NOT NULL;
+
+DROP TABLE `complete_share`;
+-- Changes in the data cache which was introduced in 1.1.0.0
+DROP TABLE `t_node_cache`;


### PR DESCRIPTION
When copying nodes, it would be slow at a specific query.
Now it is using the same cache than when we import nodes.

* Making a specific method to check cache
* Adjusting a query to it would also work on Oracle

!! If Karuta-backend 1.1.0.0 was installed, please run the update sql, there's some minor changes and it will clear the node cache