### PR TITLE
Performance improvement:

### DIFF
--- a/src/com/portfolio/data/provider/MysqlDataProvider.java
+++ b/src/com/portfolio/data/provider/MysqlDataProvider.java
@@ -10397,7 +10397,10 @@ public class MysqlDataProvider implements DataProvider {
 				paramVal[i] = line.substring(var+1);
 			}
 
-			xml = getNodeXmlOutput(nodeUuid,true,null,userId, groupId, null,true).toString();
+			/// TODO: Test this more, should use getNode rather than having another output
+			xml = getNode(new MimeType("text/xml"),nodeUuid,true, userId, groupId, null).toString();
+
+//			xml = getNodeXmlOutput(nodeUuid,true,null,userId, groupId, null,true).toString();
 			return DomUtils.processXSLTfile2String( DomUtils.xmlString2Document(xml, new StringBuffer()), xslFile, param, paramVal, new StringBuffer());
 		} catch (Exception e) {
 //			e.printStackTrace();


### PR DESCRIPTION
Fetching node and converting it via XSL was using another method that recursively fetch all node information, obviously it's slow.

Now it is connected to the general 'getNode' re-written some time ago so as to fetch data per level, and also check security in a more parallel way.