### PR TITLE
Public behavior change:

### DIFF
--- a/WebContent/version
+++ b/WebContent/version
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <versions>
 	<version id='backend'>
-		<number>1.2.0.6</number>
-		<date>2016-02-10</date>
+		<number>1.2.1.0</number>
+		<date>2016-02-15</date>
 	</version>
 	<version id='fileserver'>
 		<number>1.2.0.0</number>

--- a/sql/karuta-backend.sql
+++ b/sql/karuta-backend.sql
@@ -307,7 +307,8 @@ CREATE TABLE IF NOT EXISTS `data_table` (
 
 
 INSERT IGNORE INTO `credential` VALUES (1, 'root', 0, 1, 0, 1, 'root', '', NULL, UNHEX(SHA1('mati')), NULL, NULL);
-INSERT IGNORE INTO `credential` VALUES (2, 'public', 0, 0, 0, 1, 'Public account', '', NULL, UNHEX(SHA1('public')), NULL, NULL);
+INSERT IGNORE INTO `credential` VALUES (2, 'sys_public', 0, 0, 0, 1, 'System public account (users with account)', '', NULL, UNHEX(SHA1('THIS NEEDS TO BE CHANGED')), NULL, NULL);
+INSERT IGNORE INTO `credential` VALUES (3, 'public', 0, 0, 0, 1, 'Public account (World)', '', NULL, UNHEX(SHA1('public')), NULL, NULL);
 
 INSERT INTO `group_info` VALUES (1,1,1,'all'),(2,2,1,'designer');
 

--- a/src/com/portfolio/data/attachment/DirectURLService.java
+++ b/src/com/portfolio/data/attachment/DirectURLService.java
@@ -198,7 +198,7 @@ public class DirectURLService  extends HttpServlet {
 			{
 				int pubid = 0;
 				/// Find public id and log as such
-				String sql = "SELECT userid FROM credential WHERE login='public'";
+				String sql = "SELECT userid FROM credential WHERE login='guest'";
 				PreparedStatement st = c.prepareStatement(sql);
 				ResultSet rs = st.executeQuery();
 				rs.next();

--- a/src/com/portfolio/data/provider/DataProvider.java
+++ b/src/com/portfolio/data/provider/DataProvider.java
@@ -58,6 +58,7 @@ public interface DataProvider {
 	public String[] postCredentialFromXml(Connection c, Integer userId, String username, String password, String substitute) throws ServletException, IOException;
 	public void getCredential(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException;
 	public String getMysqlUserUid (Connection c, String login) throws Exception;
+	@Deprecated
 	public String getUserUidByTokenAndLogin(Connection c, String login, String token) throws Exception;
 	public int deleteCredential(Connection c, int userId);
 	public boolean isAdmin( Connection c, String uid );

--- a/src/com/portfolio/data/provider/MysqlDataProvider.java
+++ b/src/com/portfolio/data/provider/MysqlDataProvider.java
@@ -4601,7 +4601,10 @@ public class MysqlDataProvider implements DataProvider {
 						role.setNotify(merge);
 					}
 
-					// Check if we have to put the portfolio as public
+					// Check if base portfolio is public
+					if( cred.isPublic(c, null, portfolioUuid) )
+						setPublic = true;
+//					/*
 					meta = res.getString("metadata");
 					nodeString = "<?xml version='1.0' encoding='UTF-8' standalone='no'?><transfer "+meta+"/>";
 					is = new InputSource(new StringReader(nodeString));
@@ -4611,6 +4614,7 @@ public class MysqlDataProvider implements DataProvider {
 					Node publicatt = attribMap.getNamedItem("public");
 					if( publicatt != null && "Y".equals(publicatt.getNodeValue()) )
 						setPublic = true;
+					//*/
 				}
 				catch( Exception e )
 				{
@@ -5114,7 +5118,10 @@ public class MysqlDataProvider implements DataProvider {
 			/// Ajoute la personne dans ce groupe
 			putUserGroup(c, Integer.toString(groupid), Integer.toString(userId));
 			
-			/// Check public state and act accordingly, it's in the root node
+			/// Check base portfolio's public state and act accordingly
+			if( cred.isPublic(c, null, portfolioUuid) )
+				setPublicState(c, userId, newPortfolioUuid, true);
+			/*
 			sql = "SELECT n.metadata FROM node n, portfolio p " +
 					"WHERE n.node_uuid=p.root_node_uuid AND p.portfolio_id=uuid2bin(?)";
 			st = c.prepareStatement(sql);
@@ -5135,6 +5142,7 @@ public class MysqlDataProvider implements DataProvider {
 			{
 				ex.printStackTrace();
 			}
+			//*/
 
 		}
 		catch( Exception e )
@@ -6123,6 +6131,8 @@ public class MysqlDataProvider implements DataProvider {
 							postNotifyRoles(c, userId, portfolioUuid, uuid, merge);
 						}
 	
+						/// FIXME? Not sure why importing a node should check if the portfolio is public or not
+						/*
 						meta = res.getString("metadata");
 						nodeString = "<?xml version='1.0' encoding='UTF-8' standalone='no'?><transfer "+meta+"/>";
 						is = new InputSource(new StringReader(nodeString));
@@ -6142,6 +6152,7 @@ public class MysqlDataProvider implements DataProvider {
 						{
 							ex.printStackTrace();
 						}
+						//*/
 	
 					}
 					catch( Exception e )
@@ -7891,6 +7902,7 @@ public class MysqlDataProvider implements DataProvider {
 				}
 				else if(children.item(i).getNodeName().equals("metadata"))
 				{
+//					/*
 					try
 					{
 						String publicatt = children.item(i).getAttributes().getNamedItem("public").getNodeValue();
@@ -7900,6 +7912,7 @@ public class MysqlDataProvider implements DataProvider {
 							setPublicState(c, userId, portfolioUuid, false);
 					}
 					catch(Exception ex) {}
+					//*/
 
 					String tmpSharedRes = "";
 					try
@@ -8161,15 +8174,11 @@ public class MysqlDataProvider implements DataProvider {
 		}
 	}
 
+	@Deprecated
 	@Override
 	public String getUserUidByTokenAndLogin(Connection c, String login, String token) throws Exception
 	{
-		try{
-			return cred.getMysqlUserUidByTokenAndLogin(c, login, token);
-		}catch (ServletException e) {
-			e.printStackTrace();
-			return null;
-		}
+		return null;
 	}
 
 	@Override
@@ -8530,19 +8539,19 @@ public class MysqlDataProvider implements DataProvider {
 				c.commit();
 			}
 
-			if( isPublic )	// Insère ou retire 'public' dans le groupe 'all' du portfolio
+			if( isPublic )	// Insère ou retire 'sys_public' dans le groupe 'all' du portfolio
 			{
 				sql = "INSERT IGNORE INTO group_user(gid, userid) " +
-						"VALUES( ?, (SELECT userid FROM credential WHERE login='public'))";
+						"VALUES( ?, (SELECT userid FROM credential WHERE login='sys_public'))";
 				if (dbserveur.equals("oracle")){
 					sql = "INSERT /*+ ignore_row_on_dupkey_index(group_user,group_user_PK)*/ INTO group_user(gid, userid) " +
-							"VALUES(?,(SELECT userid FROM credential WHERE login='public'))";
+							"VALUES(?,(SELECT userid FROM credential WHERE login='sys_public'))";
 				}
 			}
 			else
 			{
 				sql = "DELETE FROM group_user " +
-						"WHERE userid=(SELECT userid FROM credential WHERE login='public') " +
+						"WHERE userid=(SELECT userid FROM credential WHERE login='sys_public') " +
 						"AND gid=?";
 			}
 
@@ -10803,6 +10812,8 @@ public class MysqlDataProvider implements DataProvider {
 			String tag = "";
 			NamedNodeMap attr = node.getAttributes();
 
+			/// Public has to be managed via the group/user function
+//			/*
 			try
 			{
 				String publicatt = attr.getNamedItem("public").getNodeValue();
@@ -10812,6 +10823,7 @@ public class MysqlDataProvider implements DataProvider {
 					setPublicState(c, userId, portfolioUid,false);
 			}
 			catch(Exception ex) {}
+			//*/
 
 			try
 			{

--- a/src/com/portfolio/rest/RestServicePortfolio.java
+++ b/src/com/portfolio/rest/RestServicePortfolio.java
@@ -1078,7 +1078,7 @@ public class RestServicePortfolio
 	@GET
 	@Consumes(MediaType.APPLICATION_XML)
 	@Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
-	public String getPortfolios(@CookieParam("user") String user, @CookieParam("credential") String token, @QueryParam("group") int groupId, @Context ServletConfig sc,@Context HttpServletRequest httpServletRequest, @HeaderParam("Accept") String accept, @QueryParam("active") String active, @QueryParam("user") Integer userId, @QueryParam("code") String code, @QueryParam("portfolio") String portfolioUuid, @QueryParam("i") String index, @QueryParam("n") String numResult, @QueryParam("level") String cutoff )
+	public String getPortfolios(@CookieParam("user") String user, @CookieParam("credential") String token, @QueryParam("group") int groupId, @Context ServletConfig sc,@Context HttpServletRequest httpServletRequest, @HeaderParam("Accept") String accept, @QueryParam("active") String active, @QueryParam("user") Integer userId, @QueryParam("code") String code, @QueryParam("portfolio") String portfolioUuid, @QueryParam("i") String index, @QueryParam("n") String numResult, @QueryParam("level") String cutoff, @QueryParam("public") String public_var )
 	{
 		UserInfo ui = checkCredential(httpServletRequest, user, token, null);
 		Connection c = null;
@@ -1112,11 +1112,16 @@ public class RestServicePortfolio
 				}
 				else
 				{
-					if( userId != null && credential.isAdmin(c, ui.userId) )	//	XXX If user is admin, can ask any specific list of portfolios as a specific user	(normally redudant with substitution) 
+					if( public_var != null )
+					{
+						int publicid = credential.getMysqlUserUid(c, "public");
+						returnValue = dataProvider.getPortfolios(c, new MimeType("text/xml"), publicid, groupId, portfolioActive, 0).toString();
+					}
+					else if( userId != null && credential.isAdmin(c, ui.userId) )	//	XXX If user is admin, can ask any specific list of portfolios as a specific user	(normally redudant with substitution) 
 					{
 						returnValue = dataProvider.getPortfolios(c, new MimeType("text/xml"), userId, groupId, portfolioActive, ui.subId).toString();
 					}
-					else
+					else	/// For user logged in
 					{
 						returnValue = dataProvider.getPortfolios(c, new MimeType("text/xml"), ui.userId, groupId, portfolioActive, ui.subId).toString();
 					}

--- a/src/com/portfolio/security/Credential.java
+++ b/src/com/portfolio/security/Credential.java
@@ -210,29 +210,27 @@ public class Credential
 		/// Create account
 	}
 
-	public String getMysqlUserUidByTokenAndLogin(Connection c, String login, String token) throws Exception
+	public int getMysqlUserUid(Connection c, String login) throws Exception
 	{
 		PreparedStatement st;
 		String sql;
 		ResultSet res;
+		int uid=0;
 
 		try
 		{
-			sql = "SELECT userid FROM credential WHERE login = ? and token = ?";
+			sql = "SELECT userid FROM credential WHERE login = ?";
 			st = c.prepareStatement(sql);
 			st.setString(1, login);
-			st.setString(2, token);
 			res = st.executeQuery();
 			if( res.next() )
-				return res.getString("userid");
-			else
-				return "0";
+				uid = res.getInt("userid");
 		}
 		catch(Exception ex)
 		{
 			ex.printStackTrace();
-			return null;
 		}
+		return uid;
 	}
 
 
@@ -473,7 +471,8 @@ public class Credential
 
 	}
 
-	/// From node, check if portoflio has user 'public' in group 'all'
+	/// From node, check if portoflio has user 'sys_public' in group 'all'
+	/// To differentiate between 'public' to the world, and 'public' to people with an account
 	public boolean isPublic( Connection c, String node_uuid, String portfolio_uuid )
 	{
 		PreparedStatement st = null;
@@ -489,7 +488,7 @@ public class Credential
 						"WHERE gri.grid=gi.grid AND gu.gid=gi.gid AND gu.userid=c.userid AND " +
 						"n.node_uuid=uuid2bin(?) AND n.portfolio_id=gri.portfolio_id " +
 						"AND gri.label='all' " +
-						"AND c.login='public'";
+						"AND c.login='sys_public'";
 				st = c.prepareStatement(sql);
 				st.setString(1, node_uuid);
 			}
@@ -500,7 +499,7 @@ public class Credential
 						"WHERE gri.grid=gi.grid AND gu.gid=gi.gid AND gu.userid=c.userid AND " +
 						"gri.portfolio_id=uuid2bin(?) " +
 						"AND gri.label='all' " +
-						"AND c.login='public'";
+						"AND c.login='sys_public'";
 				st = c.prepareStatement(sql);
 				st.setString(1, portfolio_uuid);
 			}
@@ -533,8 +532,8 @@ public class Credential
 
 		try
 		{
-			// Récupération du userid de 'public'
-			sql = "SELECT userid FROM credential WHERE login='public'";
+			// Fetching 'sys_public' userid
+			sql = "SELECT userid FROM credential WHERE login='sys_public'";
 			st = c.prepareStatement(sql);
 			res = st.executeQuery();
 			if(res.next())


### PR DESCRIPTION
There is need to differentiate 'public', free access to people within the system, with 'public', free access from the world.

Also, copy and instantiate now ignore the attribute, but check if the source portfolio is public (within the system) before setting it as such.

Direct access uses now the 'guest' account

Using the attribute 'public' on GET /portfolios now returns the list of portfolios having been made (really) public