### PR TITLE
Connection manager

### DIFF
--- a/src/com/portfolio/data/utils/ConfigUtils.java
+++ b/src/com/portfolio/data/utils/ConfigUtils.java
@@ -54,9 +54,9 @@ public class ConfigUtils
 			String value = null;
 			while ((line = readerSrce.readLine())!=null){
 				if (!line.startsWith("#") && line.length()>2) { // ce n'est pas un commentaire et longueur>=3 ex: x=b est le minumum
-					String[] tok = line.split("=");
-					variable = tok[0];
-					value = tok[1];
+					int cut = line.indexOf("=");
+					variable = line.substring(0, cut);
+					value = line.substring(cut+1);
 					attributes.put(variable, value);
 				}
 			}
@@ -81,5 +81,10 @@ public class ConfigUtils
 	public static String get( String attribute )
 	{
 		return attributes.get(attribute);
+	}
+	
+	public static void clear( String attribute )
+	{
+		attributes.remove(attribute);
 	}
 }

--- a/tomcat/karuta-backend_config/configKaruta.properties
+++ b/tomcat/karuta-backend_config/configKaruta.properties
@@ -35,8 +35,22 @@ logfile_3=other.log
 # Configuring DB type, 
 # and redirection if you plan on separating servlets on different servers (need testing)
 dataProviderClass=com.portfolio.data.provider.MysqlDataProvider
+DBUser=karuta
+DBPass=karuta_password
+DBDriver=com.mysql.jdbc.Driver
+DBUrl=jdbc:mysql://localhost/karuta-backend?useUnicode=true&useEncoding=true&characterEncoding=UTF-8
 serverType=mysql
 #serverType=oracle
+#DBDriver=oracle.jdbc.driver.OracleDriver
+#DBUrl=jdbc:oracle:thin:@//localhost:1234/KARUTA
+### Pooling configuration
+DB.MaxWait=1000
+DB.MaxTotal=100
+DB.MinIdle=1
+DB.MaxIdle=50
+DB.WaitEviction=60000
+
+### Servlet redirection (When putting services on different servers)
 backendserver=localhost:8080/karuta-backend
 fileserver=localhost:8080/karuta-fileserver
 


### PR DESCRIPTION
Tests so far hasn't shown any significant stability difference between using tomcat's context.xml and configuring the pool manager this way.

And since it's easier to maintain and upgrade different configuration, the configuration will stay outside.

!! From now on, the database configuration will be in the configKaruta.properties